### PR TITLE
Adding method validations option

### DIFF
--- a/src/EloquentInteractions/Interaction.php
+++ b/src/EloquentInteractions/Interaction.php
@@ -48,9 +48,10 @@ abstract class Interaction {
    * @param array $params Interaction parameters
    */
   public function __construct($params = []) {
-    $this->validator = Validator::make($params, $this->validations, ['object' => 'The :attribute object type is invalid.']);
-
     $this->params = $params;
+
+    $validations = method_exists($this, 'validations') ? $this->validations() : $this->validations;
+    $this->validator = Validator::make($params, $validations, ['object' => 'The :attribute object type is invalid.']);
   }
 
   /**


### PR DESCRIPTION
This method can be optionally used instead of the property `validations` for better use with custom rules. Example usage:

```php
class CreatePhoneInteraction extends Interaction
{
    public function validations()
    {
        return [
            'phone' => ['required', new MyPhoneRule('BR')],
        ];
    }
}
```